### PR TITLE
Set up our infrastructure for making calls to the engine

### DIFF
--- a/org-blog-wp.el
+++ b/org-blog-wp.el
@@ -210,6 +210,23 @@ function to make other calls."
      #'(lambda (a b)
          (string< (car a) (car b))))))
 
+;;;; RPC entry point
+
+(defun org-blog-wp-call (blog call &rest args)
+  "Easy calls to WordPress API functions.
+
+This routine will take whatever information a user has available,
+fill in the rest (if the user is willing to cooperate) and then
+call the specified function and return the results."
+  (let ((blog-id (cdr (assq :blog-id blog)))
+        (func (intern (concat "org-blog-wp-" call)))
+        (password (cdr (assq :password blog)))
+        (username (cdr (assq :username blog)))
+        (xmlrpc (cdr (assq :xmlrpc blog))))
+    (if (fboundp func)
+        (apply func xmlrpc blog-id username password args)
+      (error "Can't find function %s" func))))
+
 ;;;; Define tests if ert is loaded
 (when (featurep 'ert)
   (ert-deftest ob-test-post-to-wp ()

--- a/org-blog.el
+++ b/org-blog.el
@@ -112,6 +112,17 @@ we default to unknown."
   (unless (= 0 (length string))
     string))
 
+(defun org-blog-call (blog call &rest args)
+  "Make the specified call to the appropriate blog engine.
+
+This allows us to maintain multiple engines, with a set of
+operations common to all, and call the appropriate function based
+on the engine specification in the entry in `org-blog-alist'."
+  (let ((entry (intern (concat "org-blog-" (cdr (assq :engine blog)) "-call"))))
+    (if (fboundp entry)
+        (apply entry blog call args)
+      (error (format  "Can't find function %s" entry)))))
+
 (defun org-blog-post-to-blog (post)
   "Determine the blog to use for the given post.
 


### PR DESCRIPTION
I'm reconsidering how I'm doing this---the double indirection seems
like a code smell.  I know it's intended to keep from having to
unmarshall stuff from the blog alist in each actual xml-rpc call, but
I'm wondering if a macro mightn't be the right actual answer for that.
Or something; it just doesn't sit quite right with me at the moment.
