### PR TITLE
Don't fail all tests without password

### DIFF
--- a/Cask
+++ b/Cask
@@ -6,6 +6,7 @@
 (depends-on "org-plus-contrib")
 
 (development
+ (depends-on "dash")
  (depends-on "el-mock")
  (depends-on "ert-runner")
  (depends-on "f")

--- a/test/org-blog-test.el
+++ b/test/org-blog-test.el
@@ -74,6 +74,8 @@
       (should (string= (org-no-properties (buffer-string)) post-string)))))
 (ert-deftest ob-test-org-blog-post-to-blog ()
   "Test getting the blog information from a blog post"
+  (unless (boundp 'org-blog-test-password)
+    (ert-skip "No password set"))
   (let ((org-blog-alist `(("bar" . ((:engine . "wp")
                                     (:xmlrpc . "https://wordpress.com/xmlrpc.php")
                                     (:username . "mdorman@ironicdesign.com")
@@ -87,8 +89,9 @@
     (should (equal (org-blog-post-to-blog (org-blog-buffer-extract-post)) final-blog-param))))
 (ert-deftest ob-test-org-blog-save ()
   "Transfer from buffers to posts and back again"
-  (let* ((debug-on-error 1)
-         (blog (org-blog-wp-params `((:blog-id . 46183217)
+  (unless (boundp 'org-blog-test-password)
+    (ert-skip "No password set"))
+  (let* ((blog (org-blog-wp-params `((:blog-id . 46183217)
                                      (:directory . "~/org/blogging")
                                      (:engine . "wp")
                                      (:password . ,org-blog-test-password)

--- a/test/org-blog-wp-test.el
+++ b/test/org-blog-wp-test.el
@@ -122,6 +122,8 @@
 
 (ert-deftest ob-test-wp-params ()
   "Test getting the blog-id (and correct xmlrpc URL) via xmlrpc"
+  (unless (boundp 'org-blog-test-password)
+    (ert-skip "No password set"))
   (let ((initial-blog-param `((:xmlrpc . "https://wordpress.com/xmlrpc.php")
                               (:username . "mdorman@ironicdesign.com")
                               (:password . ,org-blog-test-password)))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,3 +1,4 @@
+(require 'dash)
 (require 'el-mock)
 (require 'ert)
 (require 'f)
@@ -10,11 +11,8 @@
 
 (add-to-list 'load-path org-blog-test/root-path)
 
-(setq org-blog-test-password (getenv "PASSWORD")
-      stack-trace-on-error t
-      xml-rpc-debug 10)
-
-(unless org-blog-test-password
-  (error "You must give the secret password in the PASSWORD env variable"))
+(-if-let (password (getenv "PASSWORD"))
+    (setq org-blog-test-password  (getenv "PASSWORD")
+          xml-rpc-debug 10))
 
 (require 'org-blog)


### PR DESCRIPTION
If the password's not set, simply skip the tests that really require
one.